### PR TITLE
Add the schema to policy custom resource

### DIFF
--- a/.helm/templates/crd-policy-set.yaml
+++ b/.helm/templates/crd-policy-set.yaml
@@ -22,6 +22,8 @@ spec:
             spec:
               type: object
               properties:
+                schema:
+                  type: string
                 active:
                   type: boolean
                 policies:


### PR DESCRIPTION
Part of https://github.com/SneaksAndData/terraform-provider-boxer/issues/25

## Scope

Implemented:
- Added the missing `schema` field to policy set resource
