### PR TITLE
Add the validator schema to the EID document

### DIFF
--- a/.helm/templates/crd-external-identity.yaml
+++ b/.helm/templates/crd-external-identity.yaml
@@ -28,6 +28,8 @@ spec:
                   type: string
                 id:
                   type: string
+                validatorSchemaId:
+                  type: string
                 principalRef:
                   type: object
                   properties:


### PR DESCRIPTION
Part of https://github.com/SneaksAndData/terraform-provider-boxer/issues/8

## Scope

Implemented:
- Added the `validatorSchemaId` to the External Identity Document

## Checklist

- [ ] GitHub issue exists for this change.
- [ ] Unit tests added and they pass.
- [ ] Line Coverage is at least 80%.
- [ ] Review requested on `latest` commit.